### PR TITLE
LoadMoves() now takes a string argument

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ var (
 	Intro = flag.Bool("intro", false, "Channel Introductions")
 )
 
-var Apoc = moves.LoadMoves()
+var Apoc = moves.LoadMoves("basic.json")
 var ApocList = MakeList(Apoc)
 var Announce = make(map[string]bool)
 

--- a/moves/moves.go
+++ b/moves/moves.go
@@ -53,9 +53,9 @@ type Move []struct {
 	Crit string `json:"Crit"`
 }
 
-func LoadMoves() Move {
+func LoadMoves(filename string) Move {
 	var mv Move
-	file, e := ioutil.ReadFile("basic.json")
+	file, e := ioutil.ReadFile(filename)
 	if e != nil {
 		log.Printf("File error: %v\n", e)
 		os.Exit(1)


### PR DESCRIPTION
basic.json still hardcoded, but now it's in main.go instead of moves.go. It's a minor change, but a necessary one to move towards having multiple move files.